### PR TITLE
Move script hashes to config register

### DIFF
--- a/contracts/v1/Admin/Config.es
+++ b/contracts/v1/Admin/Config.es
@@ -25,7 +25,9 @@
   //  R5: MUT (Coll[Coll[Byte]]) Collection of script hashes for contracts making up the bitdomains protocol.
   //        R5[0] = ReservedResolverHash
   //        R5[1] = ResolverHash
-  //  R6: MUT ((Int, Coll[Byte])) Pair of base price for domain in USD and the NFT id of the oracle pool providing the price feed.
+  //  R6: MUT ((Coll[Int], Coll[Byte])) Pair of prices for protocol actions in USD and the NFT id of the oracle pool providing the price feed.
+  //        R6._1[0] = ResolverReservation price
+  //        R6._1[1] = MintResolver price
   //  R7: MUT (Coll[(SigmaProp, Int)])  Collection of fee collector -> fee basis points pairs.
   //        R7[0] = dev
   //        R7[1] = ui (SigmaProp should be unused here as it will be provided by the UI dev at tx build time via ContextVar)

--- a/contracts/v1/Admin/Config.es
+++ b/contracts/v1/Admin/Config.es
@@ -1,4 +1,5 @@
-{ // Config script
+{
+  // Config script
   //
   // TRANSACTIONS
   //
@@ -20,7 +21,15 @@
   //  tokens(0): configNft
   //
   // REGISTERS
-  //  R4: MUT (AvlTree) TLD state tree. Maintains valid registrars such as "erg" & "ada"
+  //  R4: MUT (AvlTree) TLD state tree. Maintains valid registrars such as "erg" & "ada".
+  //  R5: MUT (Coll[Coll[Byte]]) Collection of script hashes for contracts making up the bitdomains protocol.
+  //        R5[0] = ReservedResolverHash
+  //        R5[1] = ResolverHash
+  //  R6: MUT ((Int, Coll[Byte])) Pair of base price for domain in USD and the NFT id of the oracle pool providing the price feed.
+  //  R7: MUT (Coll[(SigmaProp, Int)])  Collection of fee collector -> fee basis points pairs.
+  //        R7[0] = dev
+  //        R7[1] = ui (SigmaProp should be unused here as it will be provided by the UI dev at tx build time via ContextVar)
+  //        R7[2] = DAO
   //
   // VARIABLES
   //  0: (Byte)       Action flag (ActionUpdateTld == 0x1)
@@ -29,6 +38,9 @@
 
   // constants
   val ActionUpdateTld = 1.toByte
+  val ActionUpdateScriptHashes = 2.toByte
+  val ActionUpdatePricing = 3.toByte
+  val ActionUpdateFees = 4.toByte
 
   // action to perform flag
   val action = getVar[Byte](0).get
@@ -44,11 +56,9 @@
   // nfts
   val adminNft = fromBase16("$adminNft")
 
-  // configuration
-  val cfgTldState = SELF.R4[AvlTree].get
-
   // validity
   val validUpdateTld = {
+    val cfgTldState = SELF.R4[AvlTree].get
     val proof = getVar[Coll[Byte]](2).get
 
     val newTldVal = getVar[Coll[Byte]](1).get

--- a/contracts/v1/Registry/MintResolver.es
+++ b/contracts/v1/Registry/MintResolver.es
@@ -51,7 +51,7 @@
   val resolveAddress = requestInBox.R8[Coll[Byte]].get
 
   // nfts
-  val expectedNftId = INPUTS(0).id
+  val expectedResolverNftId = INPUTS(0).id
 
   // validity
   // valid registry in box
@@ -75,8 +75,9 @@
   }
 
   val validResolverBox = {
+    val scriptHashes = config.R5[Coll[Coll[Byte]]].get
     // valid script
-    val validScript = blake2b256(resolverOutBox.propositionBytes) == fromBase16("$resolverScriptHash")
+    val validScript = blake2b256(resolverOutBox.propositionBytes) == scriptHashes(1)
     // valid registers
     val validOwnerProp = resolverOutBox.R4[SigmaProp].get == buyerProp
     val validOutLabel = resolverOutBox.R5[Coll[Byte]].get == label
@@ -84,7 +85,7 @@
     val validAddress = resolverOutBox.R7[Coll[Byte]].get == resolveAddress
     // valid tokens
     val nft = resolverOutBox.tokens(0)
-    val validOutNft = nft._1 == expectedNftId && nft._2 == 1L
+    val validOutNft = nft._1 == expectedResolverNftId && nft._2 == 1L
     val validTokens = resolverOutBox.tokens.size == 1
 
     validScript &&
@@ -101,7 +102,7 @@
     val resolversProof = getVar[Coll[Byte]](1).get
     val currentResolvers = registryInBox.R4[AvlTree].get
 
-    val insertOps: Coll[(Coll[Byte], Coll[Byte])] = Coll((hashedResolver, expectedNftId)) // expectedNftId validated in validResolverBox
+    val insertOps: Coll[(Coll[Byte], Coll[Byte])] = Coll((hashedResolver, expectedResolverNftId)) // expectedResolverNftId validated in validResolverBox
     val expectedResolvers = currentResolvers.insert(insertOps, resolversProof).get
     val updatedResolvers = registryOutBox.R4[AvlTree].get
 

--- a/src/main/scala/bitdomains/Constants.scala
+++ b/src/main/scala/bitdomains/Constants.scala
@@ -25,9 +25,7 @@ object Constants {
     "adminNft" -> adminNft,
     "registryNft" -> registryNft,
     "configNft" -> configNft,
-    "resolverReservationNft" -> resolverReservationNft,
-    "resolverScriptHash" -> Utils.bytesToHex(resolverScriptHash),
-    "reservedResolverScriptHash" -> Utils.bytesToHex(reservedResolverScriptHash)
+    "resolverReservationNft" -> resolverReservationNft
   )
 
   private def substitute(

--- a/src/test/scala/Playground.scala
+++ b/src/test/scala/Playground.scala
@@ -1,0 +1,66 @@
+import org.bitdomains.contracts._
+import org.ergoplatform.appkit.{Address, ConstantsBuilder}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should
+import scorex.crypto.hash.Blake2b256
+
+// Just a place to test random ErgoScript
+class Playground
+    extends AnyFlatSpec
+    with should.Matchers
+    with WithBlockchainContext {
+  it should "execute playground test!" in {
+    withBlockchain { implicit ctx =>
+      val script =
+        s"""{
+           |  val c1 = Coll(Coll(4, 2), Coll(1), Coll(5))
+           |  val c3 = c1.flatMap{(v: Coll[Int]) => v}
+           |
+           |  val expected = Coll(4, 2, 1, 5)
+           |  val sameEl = c3 == expected
+           |
+           |  val expectedLastEl = 5
+           |  val lastEl = c3(c3.size - 1)
+           |  val sameLastEl = lastEl == expectedLastEl
+           |
+           |  sigmaProp(sameEl && sameLastEl)
+           |}""".stripMargin
+      val tb = ctx.newTxBuilder()
+      val minStorageRent = 100000L
+
+      val map = defaultRegistryMap
+      map.ergoAVLTree
+      val tld = "test"
+//      map.insert((Blake2b256(tld), bytesToHex(tld.getBytes)))
+      println(map.digest.length)
+      println(bytesToHex(map.digest))
+
+      val prover = ctx
+        .newProverBuilder()
+        .withDLogSecret(BigInt.apply(0).bigInteger)
+        .build()
+
+      val inBox =
+        tb.outBoxBuilder
+          .value(minStorageRent + 10000000000000L)
+          .contract(ctx.compileContract(ConstantsBuilder.empty(), script))
+          .build()
+          .convertToInputWith(fakeTxId3, fakeIndex)
+
+      val outBox =
+        tb.outBoxBuilder
+          .value(minStorageRent)
+          .contract(ctx.compileContract(ConstantsBuilder.empty(), script))
+          .build()
+
+      val tx = tb
+        .fee(1e7.toLong)
+        .addInputs(inBox)
+        .addOutputs(outBox)
+        .sendChangeTo(Address.create("4MQyML64GnzMxZgm"))
+        .build()
+
+      val _ = prover.sign(tx)
+    }
+  }
+}

--- a/src/test/scala/org/bitdomains/contracts/admin/config/ConfigBoxBuilder.scala
+++ b/src/test/scala/org/bitdomains/contracts/admin/config/ConfigBoxBuilder.scala
@@ -1,20 +1,49 @@
 package org.bitdomains.contracts.admin.config
 
-import bitdomains.Constants.{configNft, configScript}
-import org.bitdomains.contracts.{RegistryState, defaultRegistryMap}
+import bitdomains.Constants.{
+  configNft,
+  configScript,
+  reservedResolverScriptHash,
+  resolverScriptHash
+}
 import org.bitdomains.contracts.utils.builders.BoxBuilder
-import org.ergoplatform.appkit.{BlockchainContext, ErgoValue, OutBox}
+import org.bitdomains.contracts.{RegistryState, defaultRegistryMap}
+import org.ergoplatform.appkit.scalaapi.ErgoValueBuilder
+import org.ergoplatform.appkit.{BlockchainContext, OutBox}
+import scorex.crypto.hash
+import sigmastate.eval.SigmaDsl
 
 case class ConfigBoxBuilder(implicit ctx: BlockchainContext)
     extends BoxBuilder(configScript, configNft) {
   private var tldState: RegistryState = defaultRegistryMap
+  private var reservedResolverHash = reservedResolverScriptHash
+  private var resolverHash = resolverScriptHash
 
   def withTldState(v: RegistryState): this.type = {
     this.tldState = v
     this
   }
 
+  def withReservedResolverHash(v: Array[Byte]): this.type = {
+    this.reservedResolverHash = hash.Digest32 @@ v
+    this
+  }
+
+  def withResolverHash(v: Array[Byte]): this.type = {
+    this.resolverHash = hash.Digest32 @@ v
+    this
+  }
+
   override def build(): OutBox = {
-    this.partialBuild().registers(tldState.ergoValue).build()
+    val scriptHashes = Array(reservedResolverHash, resolverHash)
+    val ergoColls = SigmaDsl.Colls.fromArray(
+      scriptHashes.map(SigmaDsl.Colls.fromArray(_))
+    )
+    val ergoValueScriptHashes = ErgoValueBuilder.buildFor(ergoColls)
+
+    this
+      .partialBuild()
+      .registers(tldState.ergoValue, ergoValueScriptHashes)
+      .build()
   }
 }

--- a/src/test/scala/org/bitdomains/contracts/registry/mintresolver/MintResolverSpec.scala
+++ b/src/test/scala/org/bitdomains/contracts/registry/mintresolver/MintResolverSpec.scala
@@ -10,6 +10,7 @@ import org.ergoplatform.appkit.{ErgoToken, SigmaProp, TokenBalanceException}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should
 import scorex.crypto.hash.Blake2b256
+import scorex.utils.Random
 import sigmastate.lang.exceptions.InterpreterException
 
 class MintResolverSpec
@@ -85,6 +86,19 @@ class MintResolverSpec
       val scenario = MintResolverContractScenario()
 
       scenario.resolverOut.withScript(defaultScript)
+
+      (the[InterpreterException] thrownBy scenario
+        .mkAndSignTx()).getMessage should be(
+        "Script reduced to false"
+      )
+    }
+  }
+
+  "validResolverBox" should "fail if script hash doesn't match config" in {
+    withBlockchain { implicit ctx =>
+      val scenario = MintResolverContractScenario()
+
+      scenario.configDataIn.withResolverHash(Random.randomBytes(32))
 
       (the[InterpreterException] thrownBy scenario
         .mkAndSignTx()).getMessage should be(

--- a/src/test/scala/org/bitdomains/contracts/registry/resolverreservation/ResolverReservationContractScenario.scala
+++ b/src/test/scala/org/bitdomains/contracts/registry/resolverreservation/ResolverReservationContractScenario.scala
@@ -5,6 +5,7 @@ import org.bitdomains.contracts.reservedresolver.ReservedResolverBoxBuilder
 import org.bitdomains.contracts.reserveresolverrequest.ReserveResolverRequestBoxBuilder
 import org.bitdomains.contracts.utils.scenarios.ContractScenario
 import org.bitdomains.contracts._
+import org.bitdomains.contracts.admin.config.ConfigBoxBuilder
 import org.ergoplatform.appkit.{BlockchainContext, ContextVar}
 import scorex.crypto.hash.Blake2b256
 
@@ -43,6 +44,9 @@ case class ResolverReservationContractScenario(
   var reservedResolverOutNftOverride: Option[String] = None
   var reservedResolverOutNftAmount: Int = 1
 
+  var configDataInBox =
+    ConfigBoxBuilder()
+
   def doAvlOps(
       hashedResolver: Array[Byte] = this.hashedResolver,
       insertedResolverNft: String = ""
@@ -75,6 +79,9 @@ case class ResolverReservationContractScenario(
       reservedResolverOutNftAmount
     )
 
+    val configDataIn =
+      configDataInBox.build().convertToInputWith(fakeTxId1, fakeIndex)
+
     val resolverReservationInBox = resolverReservationIn
       .build()
       .convertToInputWith(fakeTxId1, fakeIndex)
@@ -91,5 +98,6 @@ case class ResolverReservationContractScenario(
           .convertToInputWith(fakeTxId1, fakeIndex)
       )
       .withReservedResolverOut(reservedResolverOut.build())
+      .withConfigDataIn(configDataIn)
   }
 }

--- a/src/test/scala/org/bitdomains/contracts/registry/resolverreservation/ResolverReservationSpec.scala
+++ b/src/test/scala/org/bitdomains/contracts/registry/resolverreservation/ResolverReservationSpec.scala
@@ -5,6 +5,7 @@ import org.ergoplatform.appkit.{ErgoToken, JavaHelpers, SecretString, SigmaProp}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should
 import scorex.crypto.hash.Blake2b256
+import scorex.utils.Random
 import sigmastate.lang.exceptions.InterpreterException
 
 class ResolverReservationSpec
@@ -16,6 +17,19 @@ class ResolverReservationSpec
       val scenario = ResolverReservationContractScenario()
 
       noException should be thrownBy scenario.mkAndSignTx()
+    }
+  }
+
+  "validConfigBox" should "fail with incorrect nft" in {
+    withBlockchain { implicit ctx =>
+      val scenario = ResolverReservationContractScenario()
+
+      scenario.configDataInBox.withNftId(randomErgoId)
+
+      (the[InterpreterException] thrownBy scenario
+        .mkAndSignTx()).getMessage should be(
+        "Script reduced to false"
+      )
     }
   }
 
@@ -110,6 +124,19 @@ class ResolverReservationSpec
       val scenario = ResolverReservationContractScenario()
 
       scenario.reservedResolverOutNftAmount = 2
+
+      (the[InterpreterException] thrownBy scenario
+        .mkAndSignTx()).getMessage should be(
+        "Script reduced to false"
+      )
+    }
+  }
+
+  "validReservedResolverBox" should "fail if script hash is incorrect" in {
+    withBlockchain { implicit ctx =>
+      val scenario = ResolverReservationContractScenario()
+
+      scenario.configDataInBox.withReservedResolverHash(Random.randomBytes(32))
 
       (the[InterpreterException] thrownBy scenario
         .mkAndSignTx()).getMessage should be(

--- a/src/test/scala/org/bitdomains/contracts/registry/resolverreservation/ResolverReservationTransactionBuilder.scala
+++ b/src/test/scala/org/bitdomains/contracts/registry/resolverreservation/ResolverReservationTransactionBuilder.scala
@@ -17,6 +17,7 @@ case class ResolverReservationTransactionBuilder(implicit
   private var resolverReservationOut: Option[OutBox] = None
   private var reserveResolverRequestIn: Option[InputBox] = None
   private var reservedResolverOut: Option[OutBox] = None
+  private var configDataIn: Option[InputBox] = None
 
   def withRegistryIn(box: InputBox): this.type = {
     this.registryIn = Some(box)
@@ -48,6 +49,11 @@ case class ResolverReservationTransactionBuilder(implicit
     this
   }
 
+  def withConfigDataIn(box: InputBox): this.type = {
+    this.configDataIn = Some(box)
+    this
+  }
+
   override def build(): UnsignedTransaction = {
     this
       .partialBuild()
@@ -65,6 +71,7 @@ case class ResolverReservationTransactionBuilder(implicit
           reservedResolverOut
         ).flatten: _*
       )
+      .addDataInputs(Seq(configDataIn).flatten: _*)
       .build()
   }
 }


### PR DESCRIPTION
closes #27 

Allows `Resolver` & `ReservedResolver` contracts to be updated without needing to do a full migration of all bitdomains contracts.